### PR TITLE
fix: resolve macOS build error by building the sidecar for the current Tauri target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,5 @@ npm-cache/
 # Tauri / Windows local artifacts
 tauri-run.log
 nul
-src-tauri/binaries/*.exe
+src-tauri/binaries/*
 src-tauri/gen/

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@tauri-apps/api": "^2.3.0",
         "@tauri-apps/cli": "^2.3.0",
-        "@tauri-apps/plugin-dialog": "^2.2.0",
+        "@tauri-apps/plugin-dialog": "2.6.0",
         "@tauri-apps/plugin-process": "^2.2.0",
         "@tauri-apps/plugin-shell": "^2.2.0",
         "@types/react": "^18.3.18",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "npx tauri dev",
     "dev:ui": "vite",
     "build:ui": "vite build",
-    "build:sidecar": "npx pkg ai-reminder.js --target node18-win-x64 -o src-tauri/binaries/ai-reminder-x86_64-pc-windows-msvc.exe",
+    "build:sidecar": "node tools/build-sidecar.js",
     "tauri": "tauri",
     "dist": "npm run dist:portable",
     "dist:portable": "npm run build:sidecar && node tools/run-tauri-build.js --no-bundle && node tools/pack-tauri-portable.js",
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@tauri-apps/api": "^2.3.0",
     "@tauri-apps/cli": "^2.3.0",
-    "@tauri-apps/plugin-dialog": "^2.2.0",
+    "@tauri-apps/plugin-dialog": "2.6.0",
     "@tauri-apps/plugin-process": "^2.2.0",
     "@tauri-apps/plugin-shell": "^2.2.0",
     "@types/react": "^18.3.18",

--- a/tests/build-sidecar.test.js
+++ b/tests/build-sidecar.test.js
@@ -1,0 +1,19 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+
+const { resolveSidecarBuild } = require('../tools/build-sidecar');
+
+test('resolves macOS arm64 sidecar name expected by Tauri', () => {
+  assert.deepEqual(resolveSidecarBuild('darwin', 'arm64'), {
+    pkgTarget: 'node18-macos-arm64',
+    outputPath: path.join('src-tauri', 'binaries', 'ai-reminder-aarch64-apple-darwin'),
+  });
+});
+
+test('resolves Windows x64 sidecar name with exe extension', () => {
+  assert.deepEqual(resolveSidecarBuild('win32', 'x64'), {
+    pkgTarget: 'node18-win-x64',
+    outputPath: path.join('src-tauri', 'binaries', 'ai-reminder-x86_64-pc-windows-msvc.exe'),
+  });
+});

--- a/tools/build-sidecar.js
+++ b/tools/build-sidecar.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const TARGETS = {
+  darwin: {
+    x64: {
+      pkgTarget: 'node18-macos-x64',
+      tauriTriple: 'x86_64-apple-darwin',
+    },
+    arm64: {
+      pkgTarget: 'node18-macos-arm64',
+      tauriTriple: 'aarch64-apple-darwin',
+    },
+  },
+  win32: {
+    x64: {
+      pkgTarget: 'node18-win-x64',
+      tauriTriple: 'x86_64-pc-windows-msvc',
+      extension: '.exe',
+    },
+    arm64: {
+      pkgTarget: 'node18-win-arm64',
+      tauriTriple: 'aarch64-pc-windows-msvc',
+      extension: '.exe',
+    },
+  },
+  linux: {
+    x64: {
+      pkgTarget: 'node18-linux-x64',
+      tauriTriple: 'x86_64-unknown-linux-gnu',
+    },
+    arm64: {
+      pkgTarget: 'node18-linux-arm64',
+      tauriTriple: 'aarch64-unknown-linux-gnu',
+    },
+  },
+};
+
+function resolveSidecarBuild(platform = process.platform, arch = process.arch) {
+  const target = TARGETS[platform] && TARGETS[platform][arch];
+  if (!target) {
+    throw new Error(`Unsupported sidecar build target: ${platform}/${arch}`);
+  }
+
+  return {
+    pkgTarget: target.pkgTarget,
+    outputPath: path.join(
+      'src-tauri',
+      'binaries',
+      `ai-reminder-${target.tauriTriple}${target.extension || ''}`,
+    ),
+  };
+}
+
+function main() {
+  const rootDir = path.join(__dirname, '..');
+  const { pkgTarget, outputPath } = resolveSidecarBuild();
+  const absoluteOutputPath = path.join(rootDir, outputPath);
+  const pkgBinPath = require.resolve('pkg/lib-es5/bin.js', { paths: [rootDir] });
+
+  fs.mkdirSync(path.dirname(absoluteOutputPath), { recursive: true });
+
+  console.log(`[sidecar] target: ${pkgTarget}`);
+  console.log(`[sidecar] output: ${outputPath}`);
+
+  const result = spawnSync(
+    process.execPath,
+    [pkgBinPath, 'ai-reminder.js', '--target', pkgTarget, '-o', absoluteOutputPath],
+    {
+      cwd: rootDir,
+      stdio: 'inherit',
+      shell: false,
+    },
+  );
+
+  if (typeof result.status === 'number') {
+    process.exit(result.status);
+  }
+
+  console.error('[sidecar] Failed to start pkg.');
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  resolveSidecarBuild,
+};


### PR DESCRIPTION
fix err: 
```shell
error: failed to run custom build command for `ai-cli-complete-notify v2.6.0 (/Users/user/repo/ai-cli-complete-notify/src-tauri)`

Caused by:
  process didn't exit successfully: `/Users/user/repo/ai-cli-complete-notify/src-tauri/target/debug/build/ai-cli-complete-notify-85476d403d036bbc/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-env-changed=TAURI_CONFIG
  cargo:rustc-check-cfg=cfg(desktop)
  cargo:rustc-cfg=desktop
  cargo:rustc-check-cfg=cfg(mobile)
  cargo:rerun-if-changed=/Users/leo/repo/ai-cli-complete-notify/src-tauri/tauri.conf.json
  cargo:rustc-env=TAURI_ANDROID_PACKAGE_NAME_APP_NAME=notify
  cargo:rustc-env=TAURI_ANDROID_PACKAGE_NAME_PREFIX=com_aicli_complete
  cargo:rustc-check-cfg=cfg(dev)
  cargo:rustc-cfg=dev
  cargo:PERMISSION_FILES_PATH=/Users/leo/repo/ai-cli-complete-notify/src-tauri/target/debug/build/ai-cli-complete-notify-18ab02f078573e59/out/app-manifest/__app__-permission-files
  cargo:rerun-if-changed=capabilities
  cargo:rerun-if-env-changed=REMOVE_UNUSED_COMMANDS
  cargo:rustc-env=TAURI_ENV_TARGET_TRIPLE=aarch64-apple-darwin
  resource path `binaries/ai-reminder-aarch64-apple-darwin` doesn't exist
warning: build failed, waiting for other jobs to finish...
 ELIFECYCLE  Command failed with exit code 101.
```