### PR TITLE
Prevent unrelated Codex sessions from suppressing completion alerts

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -892,9 +892,7 @@ function startCodexWatchSessions({ intervalMs, log, confirmDetector, failureCont
   const seedCatchupMs = Math.max(0, Number(process.env.CODEX_SEED_CATCHUP_MS || 30000));
   const multiSessionCompleteQuietMs = Math.max(0, Number(process.env.CODEX_MULTI_SESSION_COMPLETE_QUIET_MS || 750));
   const completionCoordinator = {
-    pending: null,
-    timer: null,
-    flushing: false
+    groups: new Map()
   };
 
   function isCodexWorkResponseType(type) {
@@ -968,40 +966,93 @@ function startCodexWatchSessions({ intervalMs, log, confirmDetector, failureCont
     return lines.some((line) => /^(选项|options?)\s*[:：]/i.test(line));
   }
 
-  function clearCoordinatedCompletionTimer() {
-    if (!completionCoordinator.timer) return;
-    clearTimeout(completionCoordinator.timer);
-    completionCoordinator.timer = null;
+  function getCoordinationGroupKey(sessionOrCandidate) {
+    if (sessionOrCandidate && sessionOrCandidate.notification && sessionOrCandidate.notification.cwd) {
+      return String(sessionOrCandidate.notification.cwd);
+    }
+    if (sessionOrCandidate && sessionOrCandidate.lastCwd) {
+      return String(sessionOrCandidate.lastCwd);
+    }
+    return process.cwd();
   }
 
-  function getActiveSessionCount() {
+  function getCoordinatorGroup(groupKey) {
+    const key = String(groupKey || process.cwd());
+    let group = completionCoordinator.groups.get(key);
+    if (!group) {
+      group = {
+        pending: null,
+        timer: null,
+        flushing: false
+      };
+      completionCoordinator.groups.set(key, group);
+    }
+    return group;
+  }
+
+  function deleteCoordinatorGroupIfIdle(groupKey) {
+    const key = String(groupKey || process.cwd());
+    const group = completionCoordinator.groups.get(key);
+    if (!group) return;
+    if (group.pending || group.timer || group.flushing) return;
+    completionCoordinator.groups.delete(key);
+  }
+
+  function clearCoordinatedCompletionTimer(groupKey) {
+    const group = completionCoordinator.groups.get(String(groupKey || process.cwd()));
+    if (!group || !group.timer) return;
+    clearTimeout(group.timer);
+    group.timer = null;
+  }
+
+  function getActiveSessionCount(groupKey) {
+    const key = String(groupKey || process.cwd());
     let count = 0;
     for (const session of sessions.values()) {
-      if (session && session.state && session.state.turnActive) count += 1;
+      if (
+        session
+        && session.state
+        && session.state.turnActive
+        && getCoordinationGroupKey(session.state) === key
+      ) {
+        count += 1;
+      }
+    }
+    return count;
+  }
+
+  function getTrackedSessionCount(groupKey) {
+    const key = String(groupKey || process.cwd());
+    let count = 0;
+    for (const session of sessions.values()) {
+      if (session && session.state && getCoordinationGroupKey(session.state) === key) count += 1;
     }
     return count;
   }
 
   function markSessionActive(sessionState) {
     if (sessionState) sessionState.turnActive = true;
-    if (completionCoordinator.pending) {
-      completionCoordinator.pending.blockedByActive = true;
-      clearCoordinatedCompletionTimer();
+    const groupKey = getCoordinationGroupKey(sessionState);
+    const group = completionCoordinator.groups.get(groupKey);
+    if (group && group.pending) {
+      group.pending.blockedByActive = true;
+      clearCoordinatedCompletionTimer(groupKey);
     }
   }
 
-  async function flushCoordinatedCompletion(reason) {
-    if (completionCoordinator.flushing) return false;
-    if (getActiveSessionCount() > 0) {
-      if (completionCoordinator.pending) completionCoordinator.pending.blockedByActive = true;
+  async function flushCoordinatedCompletion(reason, groupKey) {
+    const group = completionCoordinator.groups.get(String(groupKey || process.cwd()));
+    if (!group || group.flushing) return false;
+    if (getActiveSessionCount(groupKey) > 0) {
+      if (group.pending) group.pending.blockedByActive = true;
       return false;
     }
-    const pending = completionCoordinator.pending;
+    const pending = group.pending;
     if (!pending) return false;
 
-    clearCoordinatedCompletionTimer();
-    completionCoordinator.pending = null;
-    completionCoordinator.flushing = true;
+    clearCoordinatedCompletionTimer(groupKey);
+    group.pending = null;
+    group.flushing = true;
     try {
       const result = await sendNotifications(pending.notification);
       if (pending.state) {
@@ -1013,54 +1064,58 @@ function startCodexWatchSessions({ intervalMs, log, confirmDetector, failureCont
       logger(`[watch][codex] ${summarizeResult(result)} (${suffix})`);
       return true;
     } finally {
-      completionCoordinator.flushing = false;
+      group.flushing = false;
+      deleteCoordinatorGroupIfIdle(groupKey);
     }
   }
 
   async function stageCoordinatedCompletion(candidate) {
     if (!candidate || !candidate.notification) return false;
 
-    const current = completionCoordinator.pending;
-    const activeCount = getActiveSessionCount();
+    const groupKey = getCoordinationGroupKey(candidate);
+    const group = getCoordinatorGroup(groupKey);
+    const current = group.pending;
+    const activeCount = getActiveSessionCount(groupKey);
     if (
       current
       && !current.blockedByActive
       && activeCount === 0
-      && sessions.size > 1
+      && getTrackedSessionCount(groupKey) > 1
       && multiSessionCompleteQuietMs > 0
     ) {
-      await flushCoordinatedCompletion(current.logReason || 'multi_session_quiet');
+      await flushCoordinatedCompletion(current.logReason || 'multi_session_quiet', groupKey);
     }
 
-    const nextCurrent = completionCoordinator.pending;
+    const nextCurrent = group.pending;
     const currentAt = nextCurrent ? Number(nextCurrent.completionAt || 0) : -Infinity;
     const candidateAt = Number(candidate.completionAt || 0);
     const hadActiveBlockedPending = Boolean(nextCurrent && nextCurrent.blockedByActive);
     candidate.blockedByActive = activeCount > 0;
+    candidate.groupKey = groupKey;
 
     if (!nextCurrent || candidateAt >= currentAt) {
-      completionCoordinator.pending = candidate;
+      group.pending = candidate;
     }
 
     if (activeCount > 0) {
-      clearCoordinatedCompletionTimer();
+      clearCoordinatedCompletionTimer(groupKey);
       return false;
     }
 
     if (hadActiveBlockedPending) {
-      return flushCoordinatedCompletion(candidate.logReason || 'task_complete');
+      return flushCoordinatedCompletion(candidate.logReason || 'task_complete', groupKey);
     }
 
-    if (sessions.size > 1 && multiSessionCompleteQuietMs > 0) {
-      clearCoordinatedCompletionTimer();
-      completionCoordinator.timer = setTimeout(() => {
-        completionCoordinator.timer = null;
-        void flushCoordinatedCompletion('multi_session_quiet');
+    if (getTrackedSessionCount(groupKey) > 1 && multiSessionCompleteQuietMs > 0) {
+      clearCoordinatedCompletionTimer(groupKey);
+      group.timer = setTimeout(() => {
+        group.timer = null;
+        void flushCoordinatedCompletion('multi_session_quiet', groupKey);
       }, multiSessionCompleteQuietMs);
       return false;
     }
 
-    return flushCoordinatedCompletion(candidate.logReason || 'task_complete');
+    return flushCoordinatedCompletion(candidate.logReason || 'task_complete', groupKey);
   }
 
   function buildRequestUserInputDedupeKey(payload, ts) {
@@ -1897,8 +1952,10 @@ function startCodexWatchSessions({ intervalMs, log, confirmDetector, failureCont
   const timer = setInterval(tick, Math.max(500, intervalMs || 1000));
   return () => {
     clearInterval(timer);
-    clearCoordinatedCompletionTimer();
-    completionCoordinator.pending = null;
+    for (const [groupKey] of completionCoordinator.groups.entries()) {
+      clearCoordinatedCompletionTimer(groupKey);
+    }
+    completionCoordinator.groups.clear();
     for (const session of sessions.values()) {
       try {
         if (session && typeof session.stop === 'function') session.stop();
@@ -2423,5 +2480,4 @@ function startWatch({ sources, intervalMs, geminiQuietMs, claudeQuietMs, log, co
 module.exports = {
   startWatch
 };
-
 

--- a/tests/watch-codex-multi-session.test.js
+++ b/tests/watch-codex-multi-session.test.js
@@ -126,3 +126,98 @@ test('codex watch notifies only after the parent session completes when subagent
   assert.equal(notifications[0].source, 'codex');
   assert.equal(notifications[0].outputContent, 'parent done');
 });
+
+test('codex watch does not block an unrelated session completion when another cwd is still active', async (t) => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-reminder-codex-home-'));
+  const previousEnv = {
+    CODEX_WATCH_BACKEND: process.env.CODEX_WATCH_BACKEND,
+    CODEX_FOLLOW_TOP_N: process.env.CODEX_FOLLOW_TOP_N,
+    CODEX_SEED_CATCHUP_MS: process.env.CODEX_SEED_CATCHUP_MS,
+    CODEX_STRICT_FINAL_ANSWER: process.env.CODEX_STRICT_FINAL_ANSWER,
+    CODEX_TUI_LOG_PATH: process.env.CODEX_TUI_LOG_PATH,
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+  };
+
+  const notifications = [];
+  const enginePath = require.resolve('../src/engine');
+  const watchPath = require.resolve('../src/watch');
+  const originalEngineCache = require.cache[enginePath];
+  const originalWatchCache = require.cache[watchPath];
+
+  function restore() {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    if (originalEngineCache) require.cache[enginePath] = originalEngineCache;
+    else delete require.cache[enginePath];
+    if (originalWatchCache) require.cache[watchPath] = originalWatchCache;
+    else delete require.cache[watchPath];
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+
+  t.after(restore);
+
+  process.env.CODEX_WATCH_BACKEND = 'sessions';
+  process.env.CODEX_FOLLOW_TOP_N = '5';
+  process.env.CODEX_SEED_CATCHUP_MS = '0';
+  process.env.CODEX_STRICT_FINAL_ANSWER = '1';
+  process.env.CODEX_TUI_LOG_PATH = path.join(tempHome, 'missing-codex-tui.log');
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+
+  require.cache[enginePath] = {
+    id: enginePath,
+    filename: enginePath,
+    loaded: true,
+    exports: {
+      sendNotifications: async (args) => {
+        notifications.push(args);
+        return { results: [{ ok: true }] };
+      },
+    },
+  };
+  delete require.cache[watchPath];
+  const { startWatch } = require('../src/watch');
+
+  const sessionDir = path.join(tempHome, '.codex', 'sessions', '2026', '04', '28');
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const activeFile = path.join(sessionDir, 'active.jsonl');
+  const shortFile = path.join(sessionDir, 'short.jsonl');
+  for (const filePath of [activeFile, shortFile]) {
+    fs.writeFileSync(filePath, '', 'utf8');
+  }
+
+  const logs = [];
+  const stop = startWatch({
+    sources: ['codex'],
+    intervalMs: 50,
+    log: (line) => logs.push(line),
+    confirmAlert: { enabled: false },
+  });
+  t.after(() => stop());
+
+  await sleep(650);
+
+  appendJsonl(activeFile, [
+    { timestamp: 1, type: 'turn_context', payload: { cwd: '/workspace/leader' } },
+    { timestamp: 2, type: 'event_msg', payload: { type: 'task_started', turn_id: 'leader-turn' } },
+  ]);
+  await sleep(650);
+
+  appendJsonl(shortFile, [
+    { timestamp: 3, type: 'turn_context', payload: { cwd: '/workspace/unrelated' } },
+    { timestamp: 4, type: 'event_msg', payload: { type: 'task_started', turn_id: 'short-turn' } },
+    { timestamp: 5, type: 'event_msg', payload: { type: 'agent_message', content: 'hello done' } },
+    { timestamp: 6, type: 'event_msg', payload: { type: 'task_complete', turn_id: 'short-turn', last_agent_message: 'hello done' } },
+  ]);
+
+  await waitFor(() => notifications.length === 1, { timeoutMs: 1500, intervalMs: 25 });
+  assert.equal(notifications[0].source, 'codex');
+  assert.equal(notifications[0].outputContent, 'hello done');
+  assert.ok(
+    logs.some((line) => line.includes('sent: 1/1') && line.includes('task_complete')),
+    `expected notification log, got:\n${logs.join('\n')}`
+  );
+});


### PR DESCRIPTION
## Summary
- scope Codex completion coordination by `cwd` instead of a single global queue
- preserve same-workspace multi-session quiet merging behavior
- add regression coverage for unrelated short sessions completing while another workspace stays active

## 中文说明
- 将 Codex 完成提醒的协调逻辑从全局队列改为按 `cwd` 分组协调
- 保留同一工作区下多会话的静默合并行为，避免同项目父子/并行会话重复提醒
- 修复无关工作目录中的短会话在其他会话仍活跃时被阻塞、导致完成提醒漏发的问题
- 补充回归测试，覆盖“另一个工作区仍活跃时，当前短会话完成仍应正常提醒”的场景

## Test Plan
- node --test tests/watch-codex-multi-session.test.js
- node --test tests/watch-codex-tui-failure.test.js
- npm run build:ui
