### PR TITLE
fix: improve Codex watch JSONL completion output

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -51,7 +51,7 @@ function buildDesktopErrorPreview(text, fallback) {
   return `${raw.slice(0, 97).trimEnd()}...`;
 }
 
-async function sendNotifications({ source, taskInfo, durationMs, cwd, projectNameOverride, force, summaryContext, outputContent, skipSummary, notifyKind, fromHook }) {
+async function sendNotifications({ source, taskInfo, durationMs, cwd, projectNameOverride, force, summaryContext, outputContent, skipSummary, notifyKind, fromHook, dedupeKey }) {
   const config = loadConfig();
   const sourceName = source || 'claude';
   const sourceConfig = config.sources[sourceName] || config.sources.claude;
@@ -89,7 +89,8 @@ async function sendNotifications({ source, taskInfo, durationMs, cwd, projectNam
   const projectName = projectNameOverride || getProjectName(cwdToUse);
   const sourceLabel = getSourceLabel(sourceName);
   const dedupeText = String(
-    outputContent
+    dedupeKey
+      || outputContent
       || (summaryContext && summaryContext.assistantMessage)
       || taskInfo
       || ''

--- a/src/notifiers/webhook.js
+++ b/src/notifiers/webhook.js
@@ -500,7 +500,7 @@ async function notifyWebhook({ config, title, contentText, projectName, timestam
   const useFeishuCard = readUseFeishuCard(channel);
   const summarySucceeded = Boolean(summaryUsed);
   const summaryText = summarySucceeded ? String(taskInfo || '').trim() : '';
-  const outputText = summarySucceeded ? '' : String(outputContent || '').trim();
+  const outputText = String(outputContent || '').trim();
 
   const results = [];
   for (const url of urls) {

--- a/src/watch.js
+++ b/src/watch.js
@@ -978,6 +978,23 @@ function startCodexWatchSessions({ intervalMs, log, confirmDetector, failureCont
     return lines.join('\n').trim();
   }
 
+  function extractCodexTaskCompleteMessage(payload) {
+    if (!payload || typeof payload !== 'object') return '';
+    const candidates = [
+      payload.last_agent_message,
+      payload.last_assistant_message,
+      payload.assistant_message,
+      payload.message,
+      payload.content,
+      payload.text
+    ];
+    for (const candidate of candidates) {
+      const text = extractTextFromAny(candidate).trim();
+      if (text) return text;
+    }
+    return '';
+  }
+
   function hasOptionsInRequestPrompt(text) {
     const raw = String(text || '').trim();
     if (!raw) return false;
@@ -1681,9 +1698,7 @@ function startCodexWatchSessions({ intervalMs, log, confirmDetector, failureCont
           clearPendingCompletion();
 
           const completionAt = ts != null ? ts : Date.now();
-          const lastAgentMessage = obj.payload && typeof obj.payload.last_agent_message === 'string'
-            ? obj.payload.last_agent_message
-            : '';
+          const lastAgentMessage = extractCodexTaskCompleteMessage(obj.payload);
           if (lastAgentMessage) {
             state.lastAssistantText = lastAgentMessage;
             state.lastAgentContent = lastAgentMessage;

--- a/tests/watch-codex-multi-session.test.js
+++ b/tests/watch-codex-multi-session.test.js
@@ -127,6 +127,100 @@ test('codex watch notifies only after the parent session completes when subagent
   assert.equal(notifications[0].outputContent, 'parent done');
 });
 
+test('codex watch reads task_complete content when last_agent_message is missing', async (t) => {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-reminder-codex-home-'));
+  const previousEnv = {
+    CODEX_WATCH_BACKEND: process.env.CODEX_WATCH_BACKEND,
+    CODEX_FOLLOW_TOP_N: process.env.CODEX_FOLLOW_TOP_N,
+    CODEX_SEED_CATCHUP_MS: process.env.CODEX_SEED_CATCHUP_MS,
+    CODEX_STRICT_FINAL_ANSWER: process.env.CODEX_STRICT_FINAL_ANSWER,
+    CODEX_MULTI_SESSION_COMPLETE_QUIET_MS: process.env.CODEX_MULTI_SESSION_COMPLETE_QUIET_MS,
+    CODEX_TUI_LOG_PATH: process.env.CODEX_TUI_LOG_PATH,
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+  };
+
+  const notifications = [];
+  const enginePath = require.resolve('../src/engine');
+  const watchPath = require.resolve('../src/watch');
+  const originalEngineCache = require.cache[enginePath];
+  const originalWatchCache = require.cache[watchPath];
+
+  function restore() {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    if (originalEngineCache) require.cache[enginePath] = originalEngineCache;
+    else delete require.cache[enginePath];
+    if (originalWatchCache) require.cache[watchPath] = originalWatchCache;
+    else delete require.cache[watchPath];
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  }
+
+  t.after(restore);
+
+  process.env.CODEX_WATCH_BACKEND = 'sessions';
+  process.env.CODEX_FOLLOW_TOP_N = '5';
+  process.env.CODEX_SEED_CATCHUP_MS = '0';
+  process.env.CODEX_STRICT_FINAL_ANSWER = '1';
+  process.env.CODEX_MULTI_SESSION_COMPLETE_QUIET_MS = '150';
+  process.env.CODEX_TUI_LOG_PATH = path.join(tempHome, 'missing-codex-tui.log');
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+
+  require.cache[enginePath] = {
+    id: enginePath,
+    filename: enginePath,
+    loaded: true,
+    exports: {
+      sendNotifications: async (args) => {
+        notifications.push(args);
+        return { results: [{ ok: true }] };
+      },
+    },
+  };
+  delete require.cache[watchPath];
+  const { startWatch } = require('../src/watch');
+
+  const sessionDir = path.join(tempHome, '.codex', 'sessions', '2026', '06', '02');
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const sessionFile = path.join(sessionDir, 'content-complete.jsonl');
+  fs.writeFileSync(sessionFile, '', 'utf8');
+
+  const logs = [];
+  const stop = startWatch({
+    sources: ['codex'],
+    intervalMs: 50,
+    log: (line) => logs.push(line),
+    confirmAlert: { enabled: false },
+  });
+  t.after(() => stop());
+
+  await sleep(650);
+
+  appendJsonl(sessionFile, [
+    { timestamp: 1, type: 'event_msg', payload: { type: 'task_started', turn_id: 'content-turn' } },
+    {
+      timestamp: 2,
+      type: 'event_msg',
+      payload: {
+        type: 'task_complete',
+        turn_id: 'content-turn',
+        content: [{ type: 'output_text', text: 'fallback complete output' }],
+      },
+    },
+  ]);
+
+  await waitFor(() => notifications.length === 1, { timeoutMs: 1500, intervalMs: 25 });
+  assert.equal(notifications[0].source, 'codex');
+  assert.equal(notifications[0].outputContent, 'fallback complete output');
+  assert.ok(
+    logs.some((line) => line.includes('sent: 1/1') && line.includes('task_complete')),
+    `expected task_complete notification log, got:\n${logs.join('\n')}`
+  );
+});
+
 test('codex watch suppresses Codex Desktop subagent completions from session metadata', async (t) => {
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-reminder-codex-home-'));
   const previousEnv = {

--- a/tests/webhook-feishu-card.test.js
+++ b/tests/webhook-feishu-card.test.js
@@ -1,0 +1,135 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const https = require('node:https');
+const test = require('node:test');
+
+test('Feishu card keeps Codex output content in interactive payload', async (t) => {
+  const originalRequest = https.request;
+  const previousEnv = {
+    WEBHOOK_USE_FEISHU_CARD: process.env.WEBHOOK_USE_FEISHU_CARD,
+    WEBHOOK_FORMAT: process.env.WEBHOOK_FORMAT,
+  };
+  let postedPayload = null;
+
+  t.after(() => {
+    https.request = originalRequest;
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+  delete process.env.WEBHOOK_USE_FEISHU_CARD;
+  delete process.env.WEBHOOK_FORMAT;
+
+  https.request = (_options, callback) => {
+    let body = '';
+    const req = new EventEmitter();
+    req.write = (chunk) => {
+      body += chunk.toString();
+    };
+    req.end = () => {
+      postedPayload = JSON.parse(body);
+      const res = new EventEmitter();
+      res.statusCode = 200;
+      callback(res);
+      res.emit('data', Buffer.from(JSON.stringify({ code: 0, msg: 'success' })));
+      res.emit('end');
+    };
+    req.setTimeout = () => {};
+    req.destroy = () => {};
+    return req;
+  };
+
+  delete require.cache[require.resolve('../src/notifiers/webhook')];
+  const { notifyWebhook } = require('../src/notifiers/webhook');
+
+  const result = await notifyWebhook({
+    config: {
+      channels: {
+        webhook: {
+          urls: ['https://open.feishu.cn/open-apis/bot/v2/hook/test'],
+          useFeishuCard: true,
+        },
+      },
+    },
+    title: '[Codex] app: Codex 完成',
+    contentText: 'Completed at: 2026/6/2 10:00:00\nSource: Codex',
+    projectName: 'app',
+    timestamp: '2026/6/2 10:00:00',
+    durationText: '1s',
+    sourceLabel: 'Codex',
+    taskInfo: 'Codex 完成',
+    outputContent: 'Codex final answer for Feishu card',
+    summaryUsed: false,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(postedPayload.msg_type, 'interactive');
+  assert.match(JSON.stringify(postedPayload.card), /Codex final answer for Feishu card/);
+});
+
+test('Feishu card keeps original output when summary is also present', async (t) => {
+  const originalRequest = https.request;
+  const previousEnv = {
+    WEBHOOK_USE_FEISHU_CARD: process.env.WEBHOOK_USE_FEISHU_CARD,
+    WEBHOOK_FORMAT: process.env.WEBHOOK_FORMAT,
+  };
+  let postedPayload = null;
+
+  t.after(() => {
+    https.request = originalRequest;
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+  delete process.env.WEBHOOK_USE_FEISHU_CARD;
+  delete process.env.WEBHOOK_FORMAT;
+
+  https.request = (_options, callback) => {
+    let body = '';
+    const req = new EventEmitter();
+    req.write = (chunk) => {
+      body += chunk.toString();
+    };
+    req.end = () => {
+      postedPayload = JSON.parse(body);
+      const res = new EventEmitter();
+      res.statusCode = 200;
+      callback(res);
+      res.emit('data', Buffer.from(JSON.stringify({ code: 0, msg: 'success' })));
+      res.emit('end');
+    };
+    req.setTimeout = () => {};
+    req.destroy = () => {};
+    return req;
+  };
+
+  delete require.cache[require.resolve('../src/notifiers/webhook')];
+  const { notifyWebhook } = require('../src/notifiers/webhook');
+
+  const result = await notifyWebhook({
+    config: {
+      channels: {
+        webhook: {
+          urls: ['https://open.feishu.cn/open-apis/bot/v2/hook/test'],
+          useFeishuCard: true,
+        },
+      },
+    },
+    title: '[Codex] app: brief summary',
+    contentText: 'Completed at: 2026/6/2 10:00:00\nSource: Codex',
+    projectName: 'app',
+    timestamp: '2026/6/2 10:00:00',
+    durationText: '1s',
+    sourceLabel: 'Codex',
+    taskInfo: 'brief summary',
+    outputContent: 'Full Codex answer should still be visible',
+    summaryUsed: true,
+  });
+
+  const cardText = JSON.stringify(postedPayload.card);
+  assert.equal(result.ok, true);
+  assert.match(cardText, /brief summary/);
+  assert.match(cardText, /Full Codex answer should still be visible/);
+});


### PR DESCRIPTION
This PR improves Codex watch/session JSONL completion notifications.

Changes:
- Extract Codex task completion output from multiple JSONL payload fields, not only last_agent_message.
- Use explicit dedupeKey when available for more stable notification dedupe.
- Keep original output visible in Feishu interactive cards even when summary text is present.
- Add tests for Codex watch completion output extraction and Feishu card rendering.

Verification:
- node --test tests/watch-codex-multi-session.test.js tests/webhook-feishu-card.test.js