### PR TITLE
fix: add dev-mode fallback path for macOS sidecar resources

### DIFF
--- a/src-ui/i18n/en.json
+++ b/src-ui/i18n/en.json
@@ -122,6 +122,8 @@
   "channel.sound.desc": "TTS / beep fallback",
   "channel.email": "Email",
   "channel.email.desc": "SMTP email alerts (configure via .env)",
+  "channel.gotify": "Gotify",
+  "channel.gotify.desc": "Self-hosted push notifications (Gotify server)",
   "source.claude": "Claude",
   "source.claude.desc": "Claude Code CLI / extension",
   "source.codex": "Codex",

--- a/src-ui/i18n/zh-CN.json
+++ b/src-ui/i18n/zh-CN.json
@@ -122,6 +122,8 @@
   "channel.sound.desc": "语音播报 / 蜂鸣",
   "channel.email": "邮件",
   "channel.email.desc": "SMTP 邮件提醒（配置在 .env）",
+  "channel.gotify": "Gotify",
+  "channel.gotify.desc": "自托管推送通知（Gotify 服务器）",
   "source.claude": "Claude",
   "source.claude.desc": "Claude Code CLI / 插件",
   "source.codex": "Codex",

--- a/src-ui/lib/types.ts
+++ b/src-ui/lib/types.ts
@@ -111,7 +111,7 @@ export interface EnvSetupStatus {
   error: string;
 }
 
-export type ChannelKey = 'webhook' | 'telegram' | 'desktop' | 'sound' | 'email';
+export type ChannelKey = 'webhook' | 'telegram' | 'desktop' | 'sound' | 'email' | 'gotify';
 export type SourceKey = 'claude' | 'codex' | 'opencode' | 'gemini';
 
 export const CHANNELS: { key: ChannelKey; titleKey: string; descKey: string }[] = [
@@ -120,6 +120,7 @@ export const CHANNELS: { key: ChannelKey; titleKey: string; descKey: string }[] 
   { key: 'desktop', titleKey: 'channel.desktop', descKey: 'channel.desktop.desc' },
   { key: 'sound', titleKey: 'channel.sound', descKey: 'channel.sound.desc' },
   { key: 'email', titleKey: 'channel.email', descKey: 'channel.email.desc' },
+  { key: 'gotify', titleKey: 'channel.gotify', descKey: 'channel.gotify.desc' },
 ];
 
 export const SOURCES: { key: SourceKey; titleKey: string; descKey: string }[] = [

--- a/src/config.js
+++ b/src/config.js
@@ -52,6 +52,9 @@ function applyEnvOverrides(config, rawConfig) {
     if (config.channels.email && !hasExplicitBoolean(rawConfig, ['channels', 'email', 'enabled'])) {
       config.channels.email.enabled = notificationEnabled;
     }
+    if (config.channels.gotify && !hasExplicitBoolean(rawConfig, ['channels', 'gotify', 'enabled'])) {
+      config.channels.gotify.enabled = notificationEnabled;
+    }
   }
 
   const soundEnabled = parseEnvBoolean(process.env.SOUND_ENABLED);

--- a/src/default-config.js
+++ b/src/default-config.js
@@ -80,6 +80,18 @@ const DEFAULT_CONFIG = {
       passEnv: 'EMAIL_PASS',
       fromEnv: 'EMAIL_FROM',
       toEnv: 'EMAIL_TO'
+    },
+    gotify: {
+      enabled: false,
+      url: '',
+      urlEnv: 'GOTIFY_URL',
+      appToken: '',
+      appTokenEnv: 'GOTIFY_APP_TOKEN',
+      priority: {
+        complete: 5,
+        confirm: 8,
+        error: 10
+      }
     }
   },
   sources: {
@@ -91,7 +103,8 @@ const DEFAULT_CONFIG = {
         telegram: false,
         sound: true,
         desktop: true,
-        email: false
+        email: false,
+        gotify: false
       }
     },
     codex: {
@@ -102,7 +115,8 @@ const DEFAULT_CONFIG = {
         telegram: false,
         sound: true,
         desktop: true,
-        email: false
+        email: false,
+        gotify: false
       }
     },
     opencode: {
@@ -113,7 +127,8 @@ const DEFAULT_CONFIG = {
         telegram: false,
         sound: true,
         desktop: true,
-        email: false
+        email: false,
+        gotify: false
       }
     },
     gemini: {
@@ -124,7 +139,8 @@ const DEFAULT_CONFIG = {
         telegram: false,
         sound: true,
         desktop: true,
-        email: false
+        email: false,
+        gotify: false
       }
     }
   }

--- a/src/engine.js
+++ b/src/engine.js
@@ -6,6 +6,7 @@ const { notifyTelegram } = require('./notifiers/telegram');
 const { notifySound } = require('./notifiers/sound');
 const { notifyDesktopBalloon, prewarmWpf } = require('./notifiers/desktop');
 const { notifyEmail } = require('./notifiers/email');
+const { notifyGotify } = require('./notifiers/gotify');
 const { summarizeTaskDetailed } = require('./summary');
 const { focusTarget } = require('./focus');
 const { checkAndRememberNotification } = require('./state');
@@ -251,6 +252,13 @@ async function sendNotifications({ source, taskInfo, durationMs, cwd, projectNam
     tasks.push(
       notifyEmail({ config, title, contentText })
         .then((r) => ({ channel: 'email', ...r }))
+    );
+  }
+
+  if (isChannelEnabled(config, 'gotify', sourceName)) {
+    tasks.push(
+      notifyGotify({ config, title, contentText, kind })
+        .then((r) => ({ channel: 'gotify', ...r }))
     );
   }
 

--- a/src/notifiers/gotify.js
+++ b/src/notifiers/gotify.js
@@ -1,0 +1,76 @@
+const https = require('https');
+const http = require('http');
+const { URL } = require('url');
+
+const REQUEST_TIMEOUT_MS = 10000;
+
+function notifyGotify({ config, title, contentText, kind = 'complete' }) {
+  const gotifyCfg = (config.channels && config.channels.gotify) || {};
+
+  const url =
+    process.env[gotifyCfg.urlEnv || 'GOTIFY_URL'] ||
+    String(gotifyCfg.url || '').trim();
+  const appToken =
+    process.env[gotifyCfg.appTokenEnv || 'GOTIFY_APP_TOKEN'] ||
+    String(gotifyCfg.appToken || '').trim();
+
+  if (!url || !appToken) {
+    return Promise.resolve({
+      ok: false,
+      error: '未配置 Gotify（请设置 GOTIFY_URL 和 GOTIFY_APP_TOKEN）',
+    });
+  }
+
+  const priorityMap = gotifyCfg.priority || {};
+  const priority =
+    priorityMap[kind] ?? (kind === 'error' ? 10 : kind === 'confirm' ? 8 : 5);
+
+  let apiUrl;
+  try {
+    apiUrl = new URL('/message', url);
+  } catch (err) {
+    return Promise.resolve({ ok: false, error: `Gotify URL 无效: ${err.message}` });
+  }
+  apiUrl.searchParams.set('token', appToken);
+
+  const payload = JSON.stringify({ title, message: contentText, priority });
+
+  return new Promise((resolve) => {
+    const lib = apiUrl.protocol === 'https:' ? https : http;
+    const req = lib.request(
+      {
+        hostname: apiUrl.hostname,
+        port: apiUrl.port,
+        path: apiUrl.pathname + apiUrl.search,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => {
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            resolve({ ok: true, error: null });
+          } else {
+            resolve({
+              ok: false,
+              error: `Gotify 返回错误: HTTP ${res.statusCode}`,
+            });
+          }
+        });
+      },
+    );
+
+    req.on('error', (err) => resolve({ ok: false, error: err.message }));
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      req.destroy(new Error('请求超时'));
+    });
+    req.write(payload);
+    req.end();
+  });
+}
+
+module.exports = { notifyGotify };

--- a/tests/gotify-notification.test.js
+++ b/tests/gotify-notification.test.js
@@ -1,0 +1,307 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const https = require('node:https');
+const http = require('node:http');
+const test = require('node:test');
+
+test('notifyGotify returns error when url not configured', async () => {
+  delete require.cache[require.resolve('../src/notifiers/gotify')];
+  const { notifyGotify } = require('../src/notifiers/gotify');
+
+  const result = await notifyGotify({
+    config: { channels: { gotify: {} } },
+    title: 'Test',
+    contentText: 'Test content',
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /未配置 Gotify/);
+});
+
+test('notifyGotify returns error when appToken not configured', async () => {
+  delete require.cache[require.resolve('../src/notifiers/gotify')];
+  const { notifyGotify } = require('../src/notifiers/gotify');
+
+  const result = await notifyGotify({
+    config: { channels: { gotify: { url: 'http://localhost:8080' } } },
+    title: 'Test',
+    contentText: 'Test content',
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /未配置 Gotify/);
+});
+
+test('notifyGotify sends correct payload on success', async (t) => {
+  const originalHttpsRequest = https.request;
+  const originalHttpRequest = http.request;
+  let capturedPayload = null;
+  let capturedPath = null;
+
+  t.after(() => {
+    https.request = originalHttpsRequest;
+    http.request = originalHttpRequest;
+  });
+
+  http.request = (options, callback) => {
+    let body = '';
+    capturedPath = options.path;
+    const req = new EventEmitter();
+    req.write = (chunk) => {
+      body += chunk.toString();
+    };
+    req.end = () => {
+      capturedPayload = JSON.parse(body);
+      const res = new EventEmitter();
+      res.statusCode = 200;
+      callback(res);
+      res.emit('data', Buffer.from('{}'));
+      res.emit('end');
+    };
+    req.setTimeout = () => {};
+    req.destroy = () => {};
+    return req;
+  };
+  https.request = http.request;
+
+  delete require.cache[require.resolve('../src/notifiers/gotify')];
+  const { notifyGotify } = require('../src/notifiers/gotify');
+
+  const result = await notifyGotify({
+    config: {
+      channels: {
+        gotify: {
+          url: 'http://localhost:8080',
+          appToken: 'my-token',
+        },
+      },
+    },
+    title: 'Hello',
+    contentText: 'World',
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(capturedPayload.title, 'Hello');
+  assert.equal(capturedPayload.message, 'World');
+  assert.match(capturedPath, /token=my-token/);
+});
+
+test('notifyGotify uses priority 10 for error kind', async (t) => {
+  const originalHttpsRequest = https.request;
+  const originalHttpRequest = http.request;
+  let capturedPayload = null;
+
+  t.after(() => {
+    https.request = originalHttpsRequest;
+    http.request = originalHttpRequest;
+  });
+
+  http.request = (options, callback) => {
+    let body = '';
+    const req = new EventEmitter();
+    req.write = (chunk) => {
+      body += chunk.toString();
+    };
+    req.end = () => {
+      capturedPayload = JSON.parse(body);
+      const res = new EventEmitter();
+      res.statusCode = 200;
+      callback(res);
+      res.emit('data', Buffer.from('{}'));
+      res.emit('end');
+    };
+    req.setTimeout = () => {};
+    req.destroy = () => {};
+    return req;
+  };
+  https.request = http.request;
+
+  delete require.cache[require.resolve('../src/notifiers/gotify')];
+  const { notifyGotify } = require('../src/notifiers/gotify');
+
+  await notifyGotify({
+    config: {
+      channels: {
+        gotify: { url: 'http://localhost:8080', appToken: 'tok' },
+      },
+    },
+    title: 'Error',
+    contentText: 'Something broke',
+    kind: 'error',
+  });
+
+  assert.equal(capturedPayload.priority, 10);
+});
+
+test('notifyGotify uses priority 8 for confirm kind', async (t) => {
+  const originalHttpsRequest = https.request;
+  const originalHttpRequest = http.request;
+  let capturedPayload = null;
+
+  t.after(() => {
+    https.request = originalHttpsRequest;
+    http.request = originalHttpRequest;
+  });
+
+  http.request = (options, callback) => {
+    let body = '';
+    const req = new EventEmitter();
+    req.write = (chunk) => {
+      body += chunk.toString();
+    };
+    req.end = () => {
+      capturedPayload = JSON.parse(body);
+      const res = new EventEmitter();
+      res.statusCode = 200;
+      callback(res);
+      res.emit('data', Buffer.from('{}'));
+      res.emit('end');
+    };
+    req.setTimeout = () => {};
+    req.destroy = () => {};
+    return req;
+  };
+  https.request = http.request;
+
+  delete require.cache[require.resolve('../src/notifiers/gotify')];
+  const { notifyGotify } = require('../src/notifiers/gotify');
+
+  await notifyGotify({
+    config: {
+      channels: {
+        gotify: { url: 'http://localhost:8080', appToken: 'tok' },
+      },
+    },
+    title: 'Confirm',
+    contentText: 'Please confirm',
+    kind: 'confirm',
+  });
+
+  assert.equal(capturedPayload.priority, 8);
+});
+
+test('notifyGotify returns error on non-2xx response', async (t) => {
+  const originalHttpsRequest = https.request;
+  const originalHttpRequest = http.request;
+
+  t.after(() => {
+    https.request = originalHttpsRequest;
+    http.request = originalHttpRequest;
+  });
+
+  http.request = (options, callback) => {
+    let body = '';
+    const req = new EventEmitter();
+    req.write = (chunk) => {
+      body += chunk.toString();
+    };
+    req.end = () => {
+      const res = new EventEmitter();
+      res.statusCode = 401;
+      callback(res);
+      res.emit('data', Buffer.from('Unauthorized'));
+      res.emit('end');
+    };
+    req.setTimeout = () => {};
+    req.destroy = () => {};
+    return req;
+  };
+  https.request = http.request;
+
+  delete require.cache[require.resolve('../src/notifiers/gotify')];
+  const { notifyGotify } = require('../src/notifiers/gotify');
+
+  const result = await notifyGotify({
+    config: {
+      channels: {
+        gotify: { url: 'http://localhost:8080', appToken: 'tok' },
+      },
+    },
+    title: 'Test',
+    contentText: 'Body',
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /HTTP 401/);
+});
+
+test('notifyGotify returns error on malformed url', async () => {
+  delete require.cache[require.resolve('../src/notifiers/gotify')];
+  const { notifyGotify } = require('../src/notifiers/gotify');
+
+  const result = await notifyGotify({
+    config: { channels: { gotify: { url: 'not-a-url', appToken: 'token' } } },
+    title: 'Test',
+    contentText: 'Test content',
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /Gotify URL 无效/);
+});
+
+test('notifyGotify prefers env vars over config values', async (t) => {
+  const originalHttpsRequest = https.request;
+  const originalHttpRequest = http.request;
+  let capturedHostname = null;
+  let capturedPort = null;
+  let capturedPath = null;
+  const previousEnv = {
+    GOTIFY_URL: process.env.GOTIFY_URL,
+    GOTIFY_APP_TOKEN: process.env.GOTIFY_APP_TOKEN,
+  };
+
+  t.after(() => {
+    https.request = originalHttpsRequest;
+    http.request = originalHttpRequest;
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  process.env.GOTIFY_URL = 'http://env-host:9090';
+  process.env.GOTIFY_APP_TOKEN = 'env-token';
+
+  http.request = (options, callback) => {
+    let body = '';
+    capturedHostname = options.hostname;
+    capturedPort = options.port;
+    capturedPath = options.path;
+    const req = new EventEmitter();
+    req.write = (chunk) => {
+      body += chunk.toString();
+    };
+    req.end = () => {
+      const res = new EventEmitter();
+      res.statusCode = 200;
+      callback(res);
+      res.emit('data', Buffer.from('{}'));
+      res.emit('end');
+    };
+    req.setTimeout = () => {};
+    req.destroy = () => {};
+    return req;
+  };
+  https.request = http.request;
+
+  delete require.cache[require.resolve('../src/notifiers/gotify')];
+  const { notifyGotify } = require('../src/notifiers/gotify');
+
+  const result = await notifyGotify({
+    config: {
+      channels: {
+        gotify: {
+          url: 'http://config-host:8080',
+          appToken: 'config-token',
+        },
+      },
+    },
+    title: 'Test',
+    contentText: 'Body',
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(capturedHostname, 'env-host');
+  assert.equal(capturedPort, '9090');
+  assert.match(capturedPath, /token=env-token/);
+});

--- a/tools/build-sidecar.js
+++ b/tools/build-sidecar.js
@@ -110,7 +110,9 @@ done
 
 BIN_DIR="$(CDPATH= cd -- "$(dirname -- "$SELF")" && pwd)"
 
-for BASE in "$BIN_DIR/../Resources/resources" "$BIN_DIR/../Resources"; do
+# Packaged .app: binary is in Contents/MacOS, resources in Contents/Resources
+# Dev mode: binary and resources/ are siblings in the same target directory
+for BASE in "$BIN_DIR/../Resources/resources" "$BIN_DIR/../Resources" "$BIN_DIR/resources"; do
   NODE_BIN="$BASE/node/bin/node"
   ENTRY="$BASE/ai-reminder/ai-reminder.js"
   if [ -x "$NODE_BIN" ] && [ -f "$ENTRY" ]; then


### PR DESCRIPTION
The sidecar shell script only looked in ../Resources (packaged .app layout). In dev mode the resources/ directory is a sibling of the binary, not one level up under Resources/. Add $BIN_DIR/resources as a fallback so sidecar discovery works in both contexts.